### PR TITLE
Voller TCP-Support

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1,9 +1,9 @@
 = docker-nodejs-unresponsive-app
 
-Simple node,js app NOT responding to any request except /manage/health or /api/health.
+Simple Node.js app NOT responding to any TCP request (except for the HTTP maintenance endpoints).
 
 This application is used as a system test helper for circuit breaker scenarios in real environments.
-
+Although it is meant as an HTTP application, unresponsitivity can as well be tested with any TCP-based protocol.
 
 The structure of this projects matches requirements for a Docker Hub Automated Build, e.g. https://hub.docker.com/r/eolio/docker-nodejs-unresponsive-app/
 
@@ -23,7 +23,7 @@ HTTP-GET for the switch is just used for fast testing convenience
 and does not follow any REST-oriented approach (sorry).
 
 
-.Available Methods
+.Available HTTP Methods
 |===
 |HTTP-Method |Uri |Response| Description
 

--- a/README.adoc
+++ b/README.adoc
@@ -3,7 +3,7 @@
 Simple Node.js app NOT responding to any TCP request (except for the HTTP maintenance endpoints).
 
 This application is used as a system test helper for circuit breaker scenarios in real environments.
-Although it is meant as an HTTP application, unresponsitivity can as well be tested with any TCP-based protocol.
+Although it is meant as an HTTP application, unresponsitivity can as well be tested with any TCP-based protocol (requires Node v6 or higher).
 
 The structure of this projects matches requirements for a Docker Hub Automated Build, e.g. https://hub.docker.com/r/eolio/docker-nodejs-unresponsive-app/
 

--- a/server.js
+++ b/server.js
@@ -34,4 +34,13 @@ const server = http.createServer((req, res) => {
     }
 
 });
-server.listen(8095);
+
+// Handle clientError to prevent Node from closing sockets on non-HTTP requests
+server.on('clientError', function (err, socket) {
+    // Only if App is set to responsive, kill the socket.
+    if (isResponsive) socket.destroy('Invalid request!');
+});
+
+server.listen(5672, function () {
+    console.log('Server listening on Port ' + this.address().port + '...')
+});


### PR DESCRIPTION
Moin Klaus,
ich habe deine app ein wenig generalisiert. 
Normalerweise schließt Node.js alle Sockets TCP-Sockets, wenn der Request kein HTTP-Request ist. Das kann man verhindern, indem das _error_-Event des http-Servers behandelt.

Kleines Manko: dieser Hack funktioniert erst ab Node v6. :-)